### PR TITLE
feat(MigrateFinishedHandler): Also dump on rollback.

### DIFF
--- a/src/Handlers/MigrateFinishedHandler.php
+++ b/src/Handlers/MigrateFinishedHandler.php
@@ -11,7 +11,8 @@ class MigrateFinishedHandler
     public function handle(CommandFinished $event)
     {
         if (
-            'migrate' === $event->command // CONSIDER: Also `migrate:fresh`.
+            // CONSIDER: Also `migrate:fresh`.
+            in_array($event->command, ['migrate', 'migrate:rollback'], true)
             && ! $event->input->hasParameterOption(['--help', '--pretend', '-V', '--version'])
             && env('MIGRATION_SNAPSHOT', true)
             && in_array(app()->environment(), explode(',', config('migration-snapshot.environments')), true)

--- a/tests/MigrateHookTest.php
+++ b/tests/MigrateHookTest.php
@@ -28,6 +28,25 @@ class MigrateHookTest extends TestCase
         $this->assertContains('Dumped schema', $output_string);
     }
 
+    public function test_handle_dumpsOnRollback()
+    {
+        $this->createTestTablesWithoutMigrate();
+
+        $output = new BufferedOutput();
+        $result = \Artisan::call(
+            'migrate:rollback',
+            [
+                '--path' => realpath(__DIR__ . '/migrations/setup'),
+                '--realpath' => true,
+            ],
+            $output
+        );
+        $this->assertEquals(0, $result);
+
+        $output_string = $output->fetch();
+        $this->assertContains('Dumped schema', $output_string);
+    }
+
     public function test_handle_doesNotLoadWhenDbHasMigrated()
     {
         // Make the dump file.


### PR DESCRIPTION
Rollbacks may precede deletion of a migration, so dump on rollback to keep `schema.sql` updated