### PR TITLE
feat(MigrateDumpCommand): Trim underscores from foreign-key constrain…

### DIFF
--- a/config/migration-snapshot.php
+++ b/config/migration-snapshot.php
@@ -31,4 +31,18 @@ return [
     */
 
     'reorder' => env('MIGRATION_SNAPSHOT_REORDER', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Whether to trim underscores from foreign constraints for consistency.
+    |--------------------------------------------------------------------------
+    |
+    | Percona's Online Schema Change for Mysql may prepend foreign constraints
+    | with underscores. Since it may not be used in all environments some dumped
+    | snapshots may not match, adding unnecessary noise to source control.
+    | Enable this trimming to get more consistent snapshots when PTOSC may be
+    | used.
+    |
+    */
+    'trim-underscores' => env('MIGRATION_SNAPSHOT_TRIM_UNDERSCORES', false),
 ];

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -129,6 +129,7 @@ final class MigrateDumpCommand extends \Illuminate\Console\Command
             return 1;
         }
         $schema_sql = preg_replace('/\s+AUTO_INCREMENT=[0-9]+/iu', '', $schema_sql);
+        $schema_sql = self::trimUnderscoresFromForeign($schema_sql);
         if (false === file_put_contents($schema_sql_path, $schema_sql)) {
             return 1;
         }
@@ -144,14 +145,12 @@ final class MigrateDumpCommand extends \Illuminate\Console\Command
         }
 
         $output = self::reorderMigrationRows($output);
-        $output_string = implode(PHP_EOL, $output) . PHP_EOL;
-        $output_string = self::trimUnderscoresFromForeign($output_string);
 
         // Append reordered rows, and include a line break to make SCM diffs
         // easier to read.
         file_put_contents(
             $schema_sql_path,
-            $output_string,
+            implode(PHP_EOL, $output) . PHP_EOL,
             FILE_APPEND
         );
 

--- a/tests/Mysql/MigrateDumpTest.php
+++ b/tests/Mysql/MigrateDumpTest.php
@@ -32,14 +32,14 @@ class MigrateDumpTest extends TestCase
     public function test_trimUnderscoresFromForeign()
     {
         $sql = "KEY z_index,
-  CONSTRAINT _b_fk FOREIGN KEY('b') REFERENCES b ON('b'),
-  CONSTRAINT a_fk FOREIGN KEY('a') REFERENCES a ON('a')
+  CONSTRAINT `__b_fk` FOREIGN KEY (`b`) REFERENCES `b` ON(`b`),
+  CONSTRAINT `a_fk` FOREIGN KEY (`a`) REFERENCES `a` ON(`a`)
 );";
         $trimmed = MigrateDumpCommand::trimUnderscoresFromForeign($sql);
         $this->assertEquals(
             "KEY z_index,
-  CONSTRAINT a_fk FOREIGN KEY('a') REFERENCES a ON('a'),
-  CONSTRAINT b_fk FOREIGN KEY('b') REFERENCES b ON('b')
+  CONSTRAINT `a_fk` FOREIGN KEY (`a`) REFERENCES `a` ON(`a`),
+  CONSTRAINT `b_fk` FOREIGN KEY (`b`) REFERENCES `b` ON(`b`)
 );",
             $trimmed
         );

--- a/tests/Mysql/MigrateDumpTest.php
+++ b/tests/Mysql/MigrateDumpTest.php
@@ -34,12 +34,20 @@ class MigrateDumpTest extends TestCase
         $sql = "KEY z_index,
   CONSTRAINT `__b_fk` FOREIGN KEY (`b`) REFERENCES `b` ON(`b`),
   CONSTRAINT `a_fk` FOREIGN KEY (`a`) REFERENCES `a` ON(`a`)
+);
+...KEY z2_index,
+  CONSTRAINT `__d_fk` FOREIGN KEY (`d`) REFERENCES `d` ON(`d`),
+  CONSTRAINT `c_fk` FOREIGN KEY (`c`) REFERENCES `c` ON(`c`)
 );";
         $trimmed = MigrateDumpCommand::trimUnderscoresFromForeign($sql);
         $this->assertEquals(
             "KEY z_index,
   CONSTRAINT `a_fk` FOREIGN KEY (`a`) REFERENCES `a` ON(`a`),
   CONSTRAINT `b_fk` FOREIGN KEY (`b`) REFERENCES `b` ON(`b`)
+);
+...KEY z2_index,
+  CONSTRAINT `c_fk` FOREIGN KEY (`c`) REFERENCES `c` ON(`c`),
+  CONSTRAINT `d_fk` FOREIGN KEY (`d`) REFERENCES `d` ON(`d`)
 );",
             $trimmed
         );


### PR DESCRIPTION
…t names and reorder them for consistency to workaround PTOSC quirk.

Percona's Online Schema Change can leave behind underscores on constraint names like:
``` sql
  ...,
  CONSTRAINT _b_fk FOREIGN KEY('b') REFERENCES b ON('b'),
  CONSTRAINT a_fk FOREIGN KEY('a') REFERENCES a ON('a')
);
```

This enhancement optionally trims those and sorts the constraints as if PTOSC had not been used. This minimizes noise in source control as usage of PTOSC may not be ubiquitous or consistent in all environments, yet the schema is functionally identical.
``` sql
  ...,
  CONSTRAINT a_fk FOREIGN KEY('a') REFERENCES a ON('a'),
  CONSTRAINT b_fk FOREIGN KEY('b') REFERENCES b ON('b')
);
```