### PR TITLE
toggle to include data in dump

### DIFF
--- a/config/migration-snapshot.php
+++ b/config/migration-snapshot.php
@@ -55,5 +55,5 @@ return [
     | records with special IDs which must match another environment.
     |
     */
-    'trim-underscores' => env('MIGRATION_SNAPSHOT_INCLUDE_DATA', false),
+    'include-data' => env('MIGRATION_SNAPSHOT_INCLUDE_DATA', false),
 ];

--- a/config/migration-snapshot.php
+++ b/config/migration-snapshot.php
@@ -55,5 +55,5 @@ return [
     | records with special IDs which must match another environment.
     |
     */
-    'include-data' => env('MIGRATION_SNAPSHOT_INCLUDE_DATA', false),
+    'data' => env('MIGRATION_SNAPSHOT_DATA', false),
 ];

--- a/config/migration-snapshot.php
+++ b/config/migration-snapshot.php
@@ -44,4 +44,16 @@ return [
     |
     */
     'trim-underscores' => env('MIGRATION_SNAPSHOT_TRIM_UNDERSCORES', true),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Include Data
+    |--------------------------------------------------------------------------
+    |
+    | Include existing table data in the database dump. Useful for when you
+    | have constant defined values like a system user with a specific ID or
+    | records with special IDs which must match another environment.
+    |
+    */
+    'trim-underscores' => env('MIGRATION_SNAPSHOT_INCLUDE_DATA', false),
 ];

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -84,6 +84,11 @@ final class MigrateDumpCommand extends Command
         $this->info('Finished Data Dump');
     }
 
+    /**
+     * @param array $output
+     *
+     * @return array
+     */
     public static function reorderMigrationRows(array $output) : array
     {
         if (config('migration-snapshot.reorder')) {
@@ -423,6 +428,12 @@ final class MigrateDumpCommand extends Command
         return $exit_code;
     }
 
+    /**
+     * @param array $db_config
+     * @param string $schema_sql_path
+     *
+     * @return int
+     */
     private static function sqliteDataDump(array $db_config, string $schema_sql_path) : int
     {
         // CONSIDER: Accepting command name as option or from config.

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -81,7 +81,7 @@ final class MigrateDumpCommand extends Command
             exit($exit_code);
         }
 
-        $this->info('Finished Data Dump');
+        $this->info('Dumped Data');
     }
 
     /**

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -228,7 +228,7 @@ final class MigrateDumpCommand extends \Illuminate\Console\Command
         passthru(
             $command_prefix
             . ' --file=' . escapeshellarg($schema_sql_path)
-            . (config('migration-snapshot.data') ? :'' : ' --schema-only'),
+            . (config('migration-snapshot.data') ? '' : ' --schema-only'),
             $exit_code
         );
         if (0 !== $exit_code) {

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -186,7 +186,7 @@ final class MigrateDumpCommand extends Command
             static::mysqlCommandPrefix($db_config)
             . ' --result-file=' . escapeshellarg($data_sql_path)
             . ' --no-create-info --skip-triggers'
-            . ' --ignore-table=' . escapeshellarg($db_config['database']) . '.migrations',
+            . ' --ignore-table=' . escapeshellarg($db_config['database'] . '.migrations'),
             $exit_code
         );
 

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -330,11 +330,18 @@ final class MigrateDumpCommand extends Command
         return $exit_code;
     }
 
+    /**
+     * @param array $db_config
+     * @param string $data_sql_path
+     *
+     * @return int
+     */
     private static function pgsqlDataDump(array $db_config, string $data_sql_path) : int
     {
         passthru(
             static::pgsqlCommandPrefix($db_config)
             . ' --file=' . escapeshellarg($data_sql_path)
+            . ' --exclude-table=' . escapeshellarg($db_config['database'] . '.migrations')
             . ' --data-only',
             $exit_code
         );

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -228,7 +228,7 @@ final class MigrateDumpCommand extends \Illuminate\Console\Command
         passthru(
             $command_prefix
             . ' --file=' . escapeshellarg($schema_sql_path)
-            . ' --schema-only',
+            . (config('migration-snapshot.data') ? :'' : ' --schema-only'),
             $exit_code
         );
         if (0 !== $exit_code) {
@@ -302,7 +302,7 @@ final class MigrateDumpCommand extends \Illuminate\Console\Command
                 return $exit_code;
             }
 
-            if ('migrations' === $table) {
+            if (config('migration-snapshot.data') || 'migrations' === $table) {
                 $insert_rows = array_slice($output, 4, -1);
                 $sorted = self::reorderMigrationRows($insert_rows);
                 array_splice($output, 4, -1, $sorted);

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -116,8 +116,9 @@ final class MigrateDumpCommand extends \Illuminate\Console\Command
         // console output with `$this->info` and `->error`.
         passthru(
             $command_prefix
-            . ' --result-file=' . escapeshellarg($schema_sql_path)
-            . ' --no-data',
+            . ' --result-file=' 
+            . escapeshellarg($schema_sql_path)
+            . (config('migration-snapshot.include-data') ? '' : ' --no-data'),
             $exit_code
         );
         if (0 !== $exit_code) {

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -118,7 +118,7 @@ final class MigrateDumpCommand extends \Illuminate\Console\Command
             $command_prefix
             . ' --result-file=' 
             . escapeshellarg($schema_sql_path)
-            . (config('migration-snapshot.include-data') ? '' : ' --no-data'),
+            . (config('migration-snapshot.data') ? '' : ' --no-data'),
             $exit_code
         );
         if (0 !== $exit_code) {

--- a/src/Commands/MigrateLoadCommand.php
+++ b/src/Commands/MigrateLoadCommand.php
@@ -85,6 +85,13 @@ final class MigrateLoadCommand extends Command
         }
     }
 
+    /**
+     * @param string $path
+     * @param array $db_config
+     * @param int|null $verbosity
+     *
+     * @return int
+     */
     private static function mysqlLoad(string $path, array $db_config, int $verbosity = null) : int
     {
         // CONSIDER: Supporting unix_socket.
@@ -125,6 +132,13 @@ final class MigrateLoadCommand extends Command
         return $exit_code;
     }
 
+    /**
+     * @param string $path
+     * @param array $db_config
+     * @param int|null $verbosity
+     *
+     * @return int
+     */
     private static function pgsqlLoad(string $path, array $db_config, int $verbosity = null) : int
     {
         // CONSIDER: Supporting unix_socket.
@@ -163,6 +177,13 @@ final class MigrateLoadCommand extends Command
         return $exit_code;
     }
 
+    /**
+     * @param string $path
+     * @param array $db_config
+     * @param int|null $verbosity
+     *
+     * @return int
+     */
     private static function sqliteLoad(string $path, array $db_config, int $verbosity = null) : int
     {
         // CONSIDER: Directly sending queries via Eloquent (requires parsing SQL


### PR DESCRIPTION
This will allow us to include data inside of the schema dump for things like system user constants, default clients ids, etc that we were improperly using seeders for.