### PR TITLE
feat(config/migration-snapshot.php): Add `after-dump` closure.

### DIFF
--- a/config/migration-snapshot.php
+++ b/config/migration-snapshot.php
@@ -44,7 +44,7 @@ return [
     |
     */
     'trim-underscores' => env('MIGRATION_SNAPSHOT_TRIM_UNDERSCORES', true),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Include Data
@@ -56,4 +56,18 @@ return [
     |
     */
     'data' => env('MIGRATION_SNAPSHOT_DATA', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | After Dump
+    |--------------------------------------------------------------------------
+    |
+    | Run this closure after dumping snapshot. Helps when output may vary by
+    | environment in unimportant ways which would just pollute the SCM history
+    | with noisy changes.
+    |
+    | Must accept two arguments: `function ($schema_sql_path, $data_sql_path)`.
+    |
+    */
+    'after-dump' => null,
 ];

--- a/tests/MigrateDumpTest.php
+++ b/tests/MigrateDumpTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use OrisIntel\MigrationSnapshot\Commands\MigrateDumpCommand;
+use OrisIntel\MigrationSnapshot\Tests\TestCase;
+
+class MigrateDumpTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set(
+            'migration-snapshot.after-dump',
+            function ($schema_sql_path, $data_sql_path) {
+                file_put_contents(
+                    $schema_sql_path,
+                    preg_replace(
+                        '~^/\*.*\*/;?[\r\n]+~mu', // Remove /**/ comments.
+                        '',
+                        file_get_contents($schema_sql_path)
+                    ),
+                );
+            }
+        );
+    }
+
+    public function test_dump_callsAfterDumpClosure()
+    {
+        $this->createTestTablesWithoutMigrate();
+        // TODO: Fix inclusion of `, ['--quiet' => true]` here breaking test.
+        $result = \Artisan::call('migrate:dump');
+        $this->assertEquals(0, $result);
+
+        $schema_sql = file_get_contents(
+            database_path() . MigrateDumpCommand::SCHEMA_SQL_PATH_SUFFIX
+        );
+        $this->assertNotContains('/*', $schema_sql);
+    }
+}

--- a/tests/MigrateDumpTest.php
+++ b/tests/MigrateDumpTest.php
@@ -17,7 +17,7 @@ class MigrateDumpTest extends TestCase
                         '~^/\*.*\*/;?[\r\n]+~mu', // Remove /**/ comments.
                         '',
                         file_get_contents($schema_sql_path)
-                    ),
+                    )
                 );
             }
         );


### PR DESCRIPTION
Adds closure which may run after dumping snapshot. Helps when output may vary by environment in unimportant ways which would just pollute the SCM history with noisy changes.