### PR TITLE
fix(MigrateDumpCommand): Workaround Mysql warning about GTIDs using `…

### DIFF
--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -238,7 +238,7 @@ final class MigrateDumpCommand extends Command
         // Excluding any hash or date suffix since only current is relevant.
 
         return 'mysqldump --routines --skip-add-drop-table'
-            . ' --skip-add-locks --skip-comments --skip-set-charset --tz-utc'
+            . ' --skip-add-locks --skip-comments --skip-set-charset --tz-utc --set-gtid-purged=OFF'
             . ' --host=' . escapeshellarg($db_config['host'])
             . ' --port=' . escapeshellarg($db_config['port'])
             . ' --user=' . escapeshellarg($db_config['username'])


### PR DESCRIPTION
…--set-gtid-purged=OFF` switch.

Since GTIDs aren't really relevant and their dump warning also causes non-zero exit, just exclude with switch.