### PR TITLE
fix Unparenthesized `a ? b : c ? d : e` php74

### DIFF
--- a/src/Commands/MigrateLoadCommand.php
+++ b/src/Commands/MigrateLoadCommand.php
@@ -49,7 +49,7 @@ final class MigrateLoadCommand extends Command
         $is_dropping = ! ($this->option('no-drop')
             ? true
             // Prefixing with command name since `migrate` may implicitly call.
-            : (env('MIGRATE_LOAD_NO_DROP') ? true : false));
+            : ((env('MIGRATE_LOAD_NO_DROP') ? true : false)));
 
         if ($is_dropping) {
             \Schema::dropAllViews();


### PR DESCRIPTION
In php7.4 using unparenthesized nested ternary operator is deprecated, so it throw error