### PR TITLE
Fix/checking wrong db when starting migrate

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,33 @@
+name: PHP Composer
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: composer run-script test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,23 +12,25 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_DATABASE: forge
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PASSWORD: password
-        ports:
-          - 3306:3306
       postgres:
         image: postgres:latest
         env:
           POSTGRES_DB: forge
-          POSTGRES_PASSWORD: password
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - 5432:5432
 
     steps:
+    - name: Start bundled MySQL
+      run: |
+        sudo /etc/init.d/mysql start
+        mysql -e 'CREATE DATABASE forge;' --user=root --password=root
+
     - uses: actions/checkout@v2
 
     - name: Validate composer.json and composer.lock

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         sudo /etc/init.d/mysql start
         mysql -e 'CREATE DATABASE forge;' --user=root --password=root
+        mysql -e "GRANT ALL PRIVILEGES ON forge.* TO 'forge'@'localhost' IDENTIFIED BY '';" --user=root --password=root
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,8 @@ jobs:
         image: mysql:latest
         env:
           MYSQL_DATABASE: forge
-          MYSQL_ROOT_PASSWORD: password
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PASSWORD: password
         ports:
           - 3306:3306
       postgres:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,6 +11,20 @@ jobs:
 
     runs-on: ubuntu-latest
 
+  services:
+    mysql:
+      image: mysql:latest
+      env:
+        MYSQL_ROOT_PASSWORD: password
+      ports:
+        - 3306:3306
+    postgres:
+      image: postgers:latest
+      env:
+        POSTGRES_PASSWORD: password
+      ports:
+        - 5432:5432
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,12 +15,14 @@ jobs:
       mysql:
         image: mysql:latest
         env:
+          MYSQL_DATABASE: forge
           MYSQL_ROOT_PASSWORD: password
         ports:
           - 3306:3306
       postgres:
         image: postgres:latest
         env:
+          POSTGRES_DB: forge
           POSTGRES_PASSWORD: password
         ports:
           - 5432:5432

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,7 +32,8 @@ jobs:
       run: |
         sudo /etc/init.d/mysql start
         mysql -e 'CREATE DATABASE forge;' --user=root --password=root
-        mysql -e "GRANT ALL PRIVILEGES ON forge.* TO 'forge'@'localhost' IDENTIFIED BY '';" --user=root --password=root
+        mysql -e "CREATE USER 'forge'@'localhost' IDENTIFIED BY '';" --user=root --password=root
+        mysql -e "GRANT ALL PRIVILEGES ON forge.* TO 'forge'@'localhost';" --user=root --password=root
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,7 +35,7 @@ jobs:
         sudo /etc/init.d/mysql start
         mysql -e 'CREATE DATABASE forge;' --user=root --password=root
         mysql -e "CREATE USER 'forge'@'localhost' IDENTIFIED BY '';" --user=root --password=root
-        mysql -e "GRANT ALL PRIVILEGES ON forge.* TO 'forge'@'localhost';" --user=root --password=root
+        mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'forge'@'localhost';" --user=root --password=root
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,19 +11,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
-  services:
-    mysql:
-      image: mysql:latest
-      env:
-        MYSQL_ROOT_PASSWORD: password
-      ports:
-        - 3306:3306
-    postgres:
-      image: postgers:latest
-      env:
-        POSTGRES_PASSWORD: password
-      ports:
-        - 5432:5432
+    services:
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+      postgres:
+        image: postgers:latest
+        env:
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,6 +18,7 @@ jobs:
           POSTGRES_DB: forge
           POSTGRES_USER: forge
           POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,7 +19,7 @@ jobs:
         ports:
           - 3306:3306
       postgres:
-        image: postgers:latest
+        image: postgres:latest
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           POSTGRES_DB: forge
           POSTGRES_USER: forge
-          POSTGRES_PASSWORD: postgres
+          # HACK: TestBench seems to assume blank password, at least w/GHA.
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready
@@ -28,7 +28,9 @@ jobs:
           - 5432:5432
 
     steps:
+    # Reuse bundled MySQL for speed and simplicity.
     - name: Start bundled MySQL
+      # HACK: TestBench seems to assume blank password, at least w/GHA.
       run: |
         sudo /etc/init.d/mysql start
         mysql -e 'CREATE DATABASE forge;' --user=root --password=root

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,7 @@ jobs:
         image: postgres:latest
         env:
           POSTGRES_DB: forge
+          POSTGRES_USER: forge
           POSTGRES_PASSWORD: postgres
         options: >-
           --health-cmd pg_isready

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel Migration Snapshot
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/orisintel/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/orisintel/laravel-migration-snapshot)
-[![Build Status](https://img.shields.io/travis/orisintel/laravel-migration-snapshot/master.svg?style=flat-square)](https://travis-ci.org/orisintel/laravel-migration-snapshot)
+![build](https://github.com/always-open/laravel-migration-snapshot/actions/workflows/php.yml/badge.svg)
 [![Total Downloads](https://img.shields.io/packagist/dt/orisintel/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/orisintel/laravel-migration-snapshot)
 
 Simplify and accelerate applying many migrations at once using a flattened dump

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ path where Artisan will be run.
 
 Put `migration-snapshot.php` into `config` with:
 ``` bash
-php artisan vendor:publish --provider="\OrisIntel\MigrationSnapshot\ServiceProvider"
+php artisan vendor:publish --provider="\AlwaysOpen\MigrationSnapshot\ServiceProvider"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Laravel Migration Snapshot
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/orisintel/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/orisintel/laravel-migration-snapshot)
-[![Build Status](https://img.shields.io/travis/orisintel/laravel-migration-snapshot/master.svg?style=flat-square)](https://travis-ci.org/orisintel/laravel-migration-snapshot)
-[![Total Downloads](https://img.shields.io/packagist/dt/orisintel/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/orisintel/laravel-migration-snapshot)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/always-open/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/always-open/laravel-migration-snapshot)
+[![Build Status](https://img.shields.io/travis/always-open/laravel-migration-snapshot/master.svg?style=flat-square)](https://travis-ci.org/always-open/laravel-migration-snapshot)
+[![Total Downloads](https://img.shields.io/packagist/dt/always-open/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/always-open/laravel-migration-snapshot)
 
 Simplify and accelerate applying many migrations at once using a flattened dump
 of the database schema and migrations, similar in spirit to Rails' `schema.rb`.
@@ -14,7 +14,7 @@ Works with the `mysql`, `pgsql`, and `sqlite` database drivers.
 You can install the package via composer:
 
 ``` bash
-composer require --dev orisintel/laravel-migration-snapshot
+composer require --dev always-open/laravel-migration-snapshot
 ```
 
 Database command-line utilities (such as `mysqldump` and `mysql`) must be in the
@@ -61,14 +61,11 @@ composer test
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-## Security
-
-If you discover any security related issues, please email
-opensource@orisintel.com instead of using the issue tracker.
-
 ## Credits
 
 - [Paul R. Rogers](https://github.com/paulrrogers)
+- ORIS Intelligence
+- PriceSpider (NeuIntel)
 - [All Contributors](../../contributors)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Laravel Migration Snapshot
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/orisintel/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/orisintel/laravel-migration-snapshot)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/always-open/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/always-open/laravel-migration-snapshot)
 ![build](https://github.com/always-open/laravel-migration-snapshot/actions/workflows/php.yml/badge.svg)
-[![Total Downloads](https://img.shields.io/packagist/dt/orisintel/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/orisintel/laravel-migration-snapshot)
+[![Total Downloads](https://img.shields.io/packagist/dt/always-open/laravel-migration-snapshot.svg?style=flat-square)](https://packagist.org/packages/always-open/laravel-migration-snapshot)
 
 Simplify and accelerate applying many migrations at once using a flattened dump
 of the database schema and migrations, similar in spirit to Rails' `schema.rb`.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
     ],
     "require": {
-        "php": "^7.3",
+        "php": ">=7.3",
         "laravel/framework": "^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3,^8.0",
+        "php": ">=7.3,>=8.0",
         "laravel/framework": "^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
     },
     "autoload": {
         "psr-4": {
-            "OrisIntel\\MigrationSnapshot\\": "src"
+            "AlwaysOpen\\MigrationSnapshot\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "OrisIntel\\MigrationSnapshot\\Tests\\": "tests"
+            "AlwaysOpen\\MigrationSnapshot\\Tests\\": "tests"
         }
     },
     "scripts": {
@@ -48,7 +48,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "OrisIntel\\MigrationSnapshot\\ServiceProvider"
+                "AlwaysOpen\\MigrationSnapshot\\ServiceProvider"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,23 @@
 {
-    "name": "orisintel/laravel-migration-snapshot",
+    "name": "always-open/laravel-migration-snapshot",
     "description": "Dump and load snapshots of the schema produced by individual migrations.",
     "keywords": [
-        "orisintel",
+        "always-open",
         "laravel-migration-snapshot",
         "laravel",
         "migration"
     ],
-    "homepage": "https://github.com/orisintel/laravel-migration-snapshot",
+    "homepage": "https://github.com/always-open/laravel-migration-snapshot",
     "license": "MIT",
     "authors": [
-    {
-        "name": "Paul R. Rogers",
-        "role": "Developer"
-    },
-    {
-        "name": "ORIS Intelligence",
-        "email": "info@orisintel.com",
-        "homepage": "https://orisintel.com",
-        "role": "Organization"
-    }
+        {
+            "name": "Paul R. Rogers",
+            "role": "Developer"
+        },
+        {
+            "name": "Always Open",
+            "role": "Organization"
+        }
     ],
     "require": {
         "php": "^7.3",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": "^7.3,^8.0",
         "laravel/framework": "^8.0"
     },
     "require-dev": {

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OrisIntel\MigrationSnapshot\Commands;
+namespace AlwaysOpen\MigrationSnapshot\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;

--- a/src/Commands/MigrateDumpCommand.php
+++ b/src/Commands/MigrateDumpCommand.php
@@ -78,9 +78,8 @@ final class MigrateDumpCommand extends Command
 
                 exit($exit_code);
             }
+            $this->info('Dumped Data');
         }
-
-        $this->info('Dumped Data');
 
         $after_dump = config('migration-snapshot.after-dump');
         if ($after_dump) {
@@ -321,7 +320,8 @@ final class MigrateDumpCommand extends Command
         exec(
             static::pgsqlCommandPrefix($db_config)
             . ' --table=' . escapeshellarg(($db_config['prefix'] ?? '') . 'migrations')
-            . ' --data-only --inserts',
+            . ' --data-only'
+            . ' --inserts',
             $output,
             $exit_code
         );

--- a/src/Commands/MigrateLoadCommand.php
+++ b/src/Commands/MigrateLoadCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OrisIntel\MigrationSnapshot\Commands;
+namespace AlwaysOpen\MigrationSnapshot\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -1,14 +1,14 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot;
+namespace AlwaysOpen\MigrationSnapshot;
 
 final class EventServiceProvider extends \Illuminate\Foundation\Support\Providers\EventServiceProvider
 {
     protected $listen = [
         // CONSIDER: Only registering these when Laravel version doesn't have
         // more specific hooks.
-        'Illuminate\Console\Events\CommandFinished' => ['OrisIntel\MigrationSnapshot\Handlers\MigrateFinishedHandler'],
-        'Illuminate\Console\Events\CommandStarting' => ['OrisIntel\MigrationSnapshot\Handlers\MigrateStartingHandler'],
+        'Illuminate\Console\Events\CommandFinished' => ['AlwaysOpen\MigrationSnapshot\Handlers\MigrateFinishedHandler'],
+        'Illuminate\Console\Events\CommandStarting' => ['AlwaysOpen\MigrationSnapshot\Handlers\MigrateStartingHandler'],
     ];
 }

--- a/src/Handlers/MigrateFinishedHandler.php
+++ b/src/Handlers/MigrateFinishedHandler.php
@@ -1,10 +1,10 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Handlers;
+namespace AlwaysOpen\MigrationSnapshot\Handlers;
 
 use Illuminate\Console\Events\CommandFinished;
-use OrisIntel\MigrationSnapshot\Commands\MigrateDumpCommand;
+use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
 
 class MigrateFinishedHandler
 {

--- a/src/Handlers/MigrateFinishedHandler.php
+++ b/src/Handlers/MigrateFinishedHandler.php
@@ -17,7 +17,8 @@ class MigrateFinishedHandler
             && env('MIGRATION_SNAPSHOT', true)
             && in_array(app()->environment(), explode(',', config('migration-snapshot.environments')), true)
         ) {
-            $options = MigrateStartingHandler::inputToArtisanOptions($event->input);
+            $options = MigrateStartingHandler::inputToArtisanOptions($event->input)
+                + ['--include-data' => config('migration-snapshot.data') ?? false];
             $database = $options['--database'] ?? env('DB_CONNECTION');
             $db_driver = \DB::connection($database)->getDriverName();
             if (! in_array($db_driver, MigrateDumpCommand::SUPPORTED_DB_DRIVERS, true)) {

--- a/src/Handlers/MigrateStartingHandler.php
+++ b/src/Handlers/MigrateStartingHandler.php
@@ -66,7 +66,7 @@ class MigrateStartingHandler
             // inconsistent output.
             $options = self::inputToArtisanOptions($event->input);
             $database = $options['--database'] ?? \DB::getConfig('name');
-            $db_driver = \DB::getDriverName();
+            $db_driver = \DB::connection($database)->getDriverName();
             if (! in_array($db_driver, MigrateDumpCommand::SUPPORTED_DB_DRIVERS, true)) {
                 // CONSIDER: Logging or emitting console warning.
                 return;
@@ -78,7 +78,7 @@ class MigrateStartingHandler
             // Try-catch instead of information_schema since not all have one.
             try {
                 $has_migrated_any = ! is_null(
-                    \DB::table('migrations')->value('id')
+                    \DB::connection($database)->table('migrations')->value('id')
                 );
             } catch (\PDOException $e) {
                 // No op. when table does not exist.

--- a/src/Handlers/MigrateStartingHandler.php
+++ b/src/Handlers/MigrateStartingHandler.php
@@ -1,10 +1,10 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Handlers;
+namespace AlwaysOpen\MigrationSnapshot\Handlers;
 
 use Illuminate\Console\Events\CommandStarting;
-use OrisIntel\MigrationSnapshot\Commands\MigrateDumpCommand;
+use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OrisIntel\MigrationSnapshot;
+namespace AlwaysOpen\MigrationSnapshot;
 
-use OrisIntel\MigrationSnapshot\Commands\MigrateDumpCommand;
-use OrisIntel\MigrationSnapshot\Commands\MigrateLoadCommand;
+use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
+use AlwaysOpen\MigrationSnapshot\Commands\MigrateLoadCommand;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {

--- a/tests/MigrateDumpTest.php
+++ b/tests/MigrateDumpTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use OrisIntel\MigrationSnapshot\Commands\MigrateDumpCommand;
-use OrisIntel\MigrationSnapshot\Tests\TestCase;
+use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
+use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
 
 class MigrateDumpTest extends TestCase
 {

--- a/tests/MigrateHookTest.php
+++ b/tests/MigrateHookTest.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests\Mysql;
+namespace AlwaysOpen\MigrationSnapshot\Tests\Mysql;
 
-use OrisIntel\MigrationSnapshot\Tests\TestCase;
+use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 class MigrateHookTest extends TestCase

--- a/tests/Mysql/MigrateDumpTest.php
+++ b/tests/Mysql/MigrateDumpTest.php
@@ -16,11 +16,11 @@ class MigrateDumpTest extends TestCase
         $this->assertDirectoryExists($this->schemaSqlDirectory);
         $this->assertFileExists($this->schemaSqlPath);
         $result_sql = file_get_contents($this->schemaSqlPath);
-        $this->assertStringContainsString('CREATE TABLE `test_ms`', $result_sql);
-        $this->assertStringContainsString('INSERT INTO `migrations`', $result_sql);
+        $this->assertMatchesRegularExpression("/CREATE TABLE [\`\"]{$this->dbPrefix}test_ms[\`\"]/", $result_sql);
+        $this->assertMatchesRegularExpression("/INSERT INTO [\`\"]{$this->dbPrefix}migrations[\`\"]/", $result_sql);
         $this->assertStringNotContainsString(' AUTO_INCREMENT=', $result_sql);
         $last_character = mb_substr($result_sql, -1);
-        $this->assertRegExp("/[\r\n]\z/mu", $last_character);
+        $this->assertMatchesRegularExpression("/[\r\n]\z/mu", $last_character);
     }
 
     public function test_trimUnderscoresFromForeign()
@@ -50,17 +50,17 @@ class MigrateDumpTest extends TestCase
     public function test_reorderMigrationRows()
     {
         $output = [
-            "INSERT INTO migrations VALUES (1,'0001_01_01_000001_one',1);",
-            "INSERT INTO migrations VALUES (2,'0001_01_01_000003_three',2);",
-            "INSERT INTO migrations VALUES (3,'0001_01_01_000002_two',3);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (1,'0001_01_01_000001_one',1);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (2,'0001_01_01_000003_three',2);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (3,'0001_01_01_000002_two',3);",
         ];
         $reordered = array_values(
             MigrateDumpCommand::reorderMigrationRows($output)
         );
         $this->assertEquals([
-            "INSERT INTO migrations VALUES (1,'0001_01_01_000001_one',0);",
-            "INSERT INTO migrations VALUES (2,'0001_01_01_000002_two',0);",
-            "INSERT INTO migrations VALUES (3,'0001_01_01_000003_three',0);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (1,'0001_01_01_000001_one',0);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (2,'0001_01_01_000002_two',0);",
+            "INSERT INTO {$this->dbPrefix}migrations VALUES (3,'0001_01_01_000003_three',0);",
         ], $reordered);
     }
 }

--- a/tests/Mysql/MigrateDumpTest.php
+++ b/tests/Mysql/MigrateDumpTest.php
@@ -1,10 +1,10 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests\Mysql;
+namespace AlwaysOpen\MigrationSnapshot\Tests\Mysql;
 
-use OrisIntel\MigrationSnapshot\Commands\MigrateDumpCommand;
-use OrisIntel\MigrationSnapshot\Tests\TestCase;
+use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
+use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
 
 class MigrateDumpTest extends TestCase
 {

--- a/tests/Mysql/MigrateLoadTest.php
+++ b/tests/Mysql/MigrateLoadTest.php
@@ -26,12 +26,12 @@ class MigrateLoadTest extends TestCase
 
         $this->assertEquals(0, \DB::table('test_ms')->count());
 
-        $table_name = \DB::table('information_schema.tables')
+        $table_name = \DB::table(\DB::raw('information_schema.tables'))
             ->where('table_schema', \DB::getDatabaseName())
-            ->whereNotIn('table_name', ['migrations'])
+            ->whereNotIn('table_name', ["{$this->dbPrefix}migrations"])
             ->value('table_name');
 
-        $this->assertEquals('test_ms', $table_name);
+        $this->assertEquals("{$this->dbPrefix}test_ms", $table_name);
     }
 
     // TODO: Test no-drop and prompt-when-production.

--- a/tests/Mysql/MigrateLoadTest.php
+++ b/tests/Mysql/MigrateLoadTest.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests\Mysql;
+namespace AlwaysOpen\MigrationSnapshot\Tests\Mysql;
 
-use OrisIntel\MigrationSnapshot\Tests\TestCase;
+use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
 
 class MigrateLoadTest extends TestCase
 {

--- a/tests/Postgresql/MigrateDumpTest.php
+++ b/tests/Postgresql/MigrateDumpTest.php
@@ -17,9 +17,9 @@ class MigrateDumpTest extends TestCase
         $this->assertDirectoryExists($this->schemaSqlDirectory);
         $this->assertFileExists($this->schemaSqlPath);
         $result_sql = file_get_contents($this->schemaSqlPath);
-        $this->assertRegExp('/CREATE TABLE (public\.)?test_ms /', $result_sql);
-        $this->assertRegExp('/INSERT INTO (public\.)?migrations /', $result_sql);
+        $this->assertMatchesRegularExpression("/CREATE TABLE (public\.)?{$this->dbPrefix}test_ms /", $result_sql);
+        $this->assertMatchesRegularExpression("/INSERT INTO (public\.)?{$this->dbPrefix}migrations /", $result_sql);
         $last_character = mb_substr($result_sql, -1);
-        $this->assertRegExp("/[\r\n]\z/mu", $last_character);
+        $this->assertMatchesRegularExpression("/[\r\n]\z/mu", $last_character);
     }
 }

--- a/tests/Postgresql/MigrateDumpTest.php
+++ b/tests/Postgresql/MigrateDumpTest.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests\Postgresql;
+namespace AlwaysOpen\MigrationSnapshot\Tests\Postgresql;
 
-use OrisIntel\MigrationSnapshot\Tests\TestCase;
+use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
 
 class MigrateDumpTest extends TestCase
 {

--- a/tests/Postgresql/MigrateLoadTest.php
+++ b/tests/Postgresql/MigrateLoadTest.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests\Postgresql;
+namespace AlwaysOpen\MigrationSnapshot\Tests\Postgresql;
 
-use OrisIntel\MigrationSnapshot\Tests\TestCase;
+use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
 
 class MigrateLoadTest extends TestCase
 {

--- a/tests/Postgresql/MigrateLoadTest.php
+++ b/tests/Postgresql/MigrateLoadTest.php
@@ -27,14 +27,14 @@ class MigrateLoadTest extends TestCase
 
         $this->assertEquals(0, \DB::table('test_ms')->count());
 
-        $table_name = \DB::table('information_schema.tables')
+        $table_name = \DB::table(\DB::raw('information_schema.tables'))
             ->where('table_catalog', \DB::getDatabaseName())
             ->where('table_schema', 'public')
-            ->whereNotIn('table_name', ['migrations'])
+            ->whereNotIn('table_name', ["{$this->dbPrefix}migrations"])
             ->where('table_name', 'NOT LIKE', 'pg_%')
             ->value('table_name');
 
-        $this->assertEquals('test_ms', $table_name);
+        $this->assertEquals("{$this->dbPrefix}test_ms", $table_name);
     }
 
     // TODO: Test no-drop and prompt-when-production.

--- a/tests/Sqlite/MigrateDumpTest.php
+++ b/tests/Sqlite/MigrateDumpTest.php
@@ -13,9 +13,9 @@ class MigrateDumpTest extends SqliteTestCase
         $this->assertDirectoryExists($this->schemaSqlDirectory);
         $this->assertFileExists($this->schemaSqlPath);
         $result_sql = file_get_contents($this->schemaSqlPath);
-        $this->assertRegExp('/CREATE TABLE( IF NOT EXISTS)? "test_ms" /', $result_sql);
-        $this->assertRegExp('/INSERT INTO "?migrations"? /', $result_sql);
+        $this->assertMatchesRegularExpression("/CREATE TABLE( IF NOT EXISTS)? \"{$this->dbPrefix}test_ms\" /", $result_sql);
+        $this->assertMatchesRegularExpression("/INSERT INTO \"?{$this->dbPrefix}migrations\"? /", $result_sql);
         $last_character = mb_substr($result_sql, -1);
-        $this->assertRegExp("/[\r\n]\z/mu", $last_character);
+        $this->assertMatchesRegularExpression("/[\r\n]\z/mu", $last_character);
     }
 }

--- a/tests/Sqlite/MigrateDumpTest.php
+++ b/tests/Sqlite/MigrateDumpTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests\Sqlite;
+namespace AlwaysOpen\MigrationSnapshot\Tests\Sqlite;
 
 class MigrateDumpTest extends SqliteTestCase
 {

--- a/tests/Sqlite/MigrateLoadTest.php
+++ b/tests/Sqlite/MigrateLoadTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests\Sqlite;
+namespace AlwaysOpen\MigrationSnapshot\Tests\Sqlite;
 
 
 class MigrateLoadTest extends SqliteTestCase

--- a/tests/Sqlite/SqliteTestCase.php
+++ b/tests/Sqlite/SqliteTestCase.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests\Sqlite;
+namespace AlwaysOpen\MigrationSnapshot\Tests\Sqlite;
 
-use OrisIntel\MigrationSnapshot\Tests\TestCase;
+use AlwaysOpen\MigrationSnapshot\Tests\TestCase;
 
 abstract class SqliteTestCase extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,10 @@
 <?php
 
 
-namespace OrisIntel\MigrationSnapshot\Tests;
+namespace AlwaysOpen\MigrationSnapshot\Tests;
 
 
-use OrisIntel\MigrationSnapshot\Commands\MigrateDumpCommand;
+use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -38,7 +38,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function getPackageProviders($app)
     {
-        return ['\OrisIntel\MigrationSnapshot\ServiceProvider'];
+        return ['\AlwaysOpen\MigrationSnapshot\ServiceProvider'];
     }
 
     protected function createTestTablesWithoutMigrate() : void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,7 @@ use AlwaysOpen\MigrationSnapshot\Commands\MigrateDumpCommand;
 class TestCase extends \Orchestra\Testbench\TestCase
 {
     protected $dbDefault = 'mysql';
+    protected $dbPrefix = 'omp_';
     protected $schemaSqlDirectory;
     protected $schemaSqlPath;
 
@@ -34,6 +35,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('database.default', $this->dbDefault);
+        $oldDbConnConfig = $app['config']->get('database.connections.' . $this->dbDefault) ?? [];
+        $app['config']->set(
+            'database.connections.' . $this->dbDefault,
+            ['prefix' => $this->dbPrefix] + $oldDbConnConfig
+        );
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
### Manual test steps
1. checkout locally
2. composer require local checkout from other Laravel project
3. `php artisan migrate:dump`
4. drop all tables in a test DB copy, whose connection is not the default
5. `php artisan migrate --database=…` # using test DB connection name
6. verify it loads from the dumped copy and does not run each migration from scratch